### PR TITLE
fix: terminology and link

### DIFF
--- a/docs/src/user-input/fuzzy-finding.md
+++ b/docs/src/user-input/fuzzy-finding.md
@@ -63,7 +63,7 @@ Where {{api input/find}} really shines, however, is in its ability to show a pre
 Options with previews are passed to {{api input/find}} as Janet tuples with three elements:
 
 1. The text (or columns) that the user will filter against
-1. A Janet [table](https://janet-lang.org/docs/data_structures/tables.html) describing how this option should be previewed
+1. A Janet [struct](https://janet-lang.org/docs/data_structures/structs.html) describing how this option should be previewed
 1. The value that should be returned if the user chooses this option
 
 Here are some examples:


### PR DESCRIPTION
I think what was meant in the docs was a Janet struct.

When I tried using a table as part of an argument to `input/find`, I got an error, while with a struct it worked fine :)