### PR TITLE
Tweak quoting in sample invocation

### DIFF
--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -27,7 +27,7 @@ Some examples:
 cy exec -c "(shell/attach \"$(pwd)\")"
 
 # Set a parameter on the client
-cy exec -c "(param/set :client :default-frame 'big-hex')"
+cy exec -c "(param/set :client :default-frame \"big-hex\")"
 ```
 
 #### Reading data from `cy`


### PR DESCRIPTION
This PR is a suggestion to modify the quoting in one of the invocation examples.

The existing invocation results in an error here while the suggested change appears to work (a subsequent retrieval of the associated value for `:default-frame` succeeded).