### PR TITLE
Remove empty group. Or want some other behaviour when empty group?

### DIFF
--- a/pkg/mux/screen/tree/tree.go
+++ b/pkg/mux/screen/tree/tree.go
@@ -112,8 +112,8 @@ func (t *Tree) RemoveNode(id NodeID) error {
 		return nil
 	}
 
-	parent := path[len(path)-2]
-	parent.(*Group).removeNode(node)
+	parent := path[len(path)-2].(*Group)
+	parent.removeNode(node)
 
 	t.Lock()
 	delete(t.nodes, id)
@@ -123,6 +123,10 @@ func (t *Tree) RemoveNode(id NodeID) error {
 	case *Pane:
 		node.Screen().Kill()
 		node.Cancel()
+		if len(parent.children) == 0 && len(path) > 2 {
+			parentOfParent := path[len(path) - 3]  
+			parentOfParent.(*Group).removeNode(parent)
+		}
 	case *Group:
 		for _, child := range node.children {
 			t.RemoveNode(child.Id())

--- a/pkg/mux/screen/tree/tree_test.go
+++ b/pkg/mux/screen/tree/tree_test.go
@@ -62,6 +62,15 @@ func TestRemoveNode(t *testing.T) {
 	tree.RemoveNode(child.Id())
 	require.Equal(t, 2, len(tree.Leaves()))
 	require.Equal(t, 2, len(g.Children()))
+	require.Equal(t, 1, len(tree.Root().Children()))
+
+	for _, child := range g.Children() {
+		tree.RemoveNode(child.Id())
+	}
+
+	require.Equal(t, 0, len(g.Children()))
+	require.Equal(t, 0, len(tree.Leaves()))
+	require.Equal(t, 0, len(tree.Root().Children()))
 }
 
 func TestRemoveRoot(t *testing.T) {


### PR DESCRIPTION
Not sure if this is the behaviour you want when there no more children in
a group. So this is more of a question what you want to do when there is an
empty group after removing last child?

**Bug that brought this up:**
1. Create project (group)
2. Remove project's editor
3. Remove project's shell
4. Try to open projects list (ctrl+a k)

Get and error:
```
{"level":"error","time":"2024-12-03T14:01:01+02:00","message":"an error occurred while running [ctrl+a k]: expected integer key for array in range [0, 0), got 0"}

```
This happens because project's children are removed but the project (group) itself 
has been not.

When fixing this problem I realized that I was not sure what kind of behaviour
would be wanted when group becomes empty. 
Things to consider:
- Want to keep the empty group?
- Treat projects and groups differently when they are empty?
- Have confirmation popup if group is about to removed? Or ask if they want to
keep empty group?
- Consider something else?

And while writing this I realized that after removing group there might a 
parent group that is now empty. So would have to walk up the tree and check.
So would have to code that if this is the wanted solution.
