### PR TITLE
Fix cursor style rendering/output

### DIFF
--- a/pkg/emu/module.go
+++ b/pkg/emu/module.go
@@ -221,11 +221,12 @@ type CursorStyle int
 
 const (
 	CursorStyleBlock CursorStyle = iota
+	CursorStyleBlinkBlock
 	CursorStyleSteadyBlock
-	CursorStyleUnderline
 	CursorStyleBlinkUnderline
-	CursorStyleBar
+	CursorStyleUnderline
 	CursorStyleBlinkBar
+	CursorStyleBar
 )
 
 type Cursor struct {

--- a/pkg/emu/parse.go
+++ b/pkg/emu/parse.go
@@ -336,17 +336,9 @@ func (t *State) CsiDispatch(params []int64, intermediates []byte, ignore bool, r
 		t.restoreCursor(false)
 	case 'q': // DECSCUSR - set cursor style
 		style := CursorStyleBlock
-		switch c.arg(0, 0) {
-		case 2:
-			style = CursorStyleSteadyBlock
-		case 3:
-			style = CursorStyleUnderline
-		case 4:
-			style = CursorStyleBlinkUnderline
-		case 5:
-			style = CursorStyleBar
-		case 6:
-			style = CursorStyleBlinkBar
+		val := c.arg(0, 0);
+		if 0 < val && val <= 6 {
+			style = CursorStyle(val)
 		}
 		t.cur.Style = style
 	case 't': // XTWINOPS - window manipulation (ignored)

--- a/pkg/geom/tty/render.go
+++ b/pkg/geom/tty/render.go
@@ -129,7 +129,7 @@ func Swap(
 	info.Fprintf(data, terminfo.CursorAddress, srcCursor.R, srcCursor.C)
 
 	if dstCursor.Style != srcCursor.Style {
-		fmt.Fprintf(data, "\x1b[%d q", int(srcCursor.Style)+1)
+		fmt.Fprintf(data, "\x1b[%d q", int(srcCursor.Style))
 	}
 
 	// This is wasteful, we shouldn't have to include this on every frame


### PR DESCRIPTION
Had a weird bug in ghostty where cursor started blinking after exiting helix.

Based on [Cursor Shape codes](https://gist.github.com/StarIitNova/4882da63dad6f4e212afb21a630c0b8e#cursor-shapes) discovered that wrong cursor codes were output. In my case got code "0" but the output was "1" because the "+1".

Replace switch statement from "pkg/emu/parse.go" with if statement. Let me know if you want back switch 
statement for better readability?


Offtopic:
Ghostty terminal has a terminal inspector (like web inspector). Might be useful for people who develop for terminal. [Year old post with video example](https://mitchellh.com/writing/ghostty-devlog-005#terminal-inspector-728).