### PR TITLE
fix: resolve deadlock in Player.consume() causing flaky TestAPI

### DIFF
--- a/pkg/replay/player/module.go
+++ b/pkg/replay/player/module.go
@@ -53,24 +53,17 @@ func (p *Player) resetTerminal() {
 }
 
 func (p *Player) consume(event sessions.Event) {
-	if p.retainOutputData {
-		p.mu.Lock()
-		p.events = append(p.events, event)
-		index := len(p.events) - 1
-		p.mu.Unlock()
-		p.Goto(index, -1)
-		return
-	}
-
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	stored := event
 	var outputData []byte
-	switch e := event.Message.(type) {
-	case P.OutputMessage:
-		outputData = e.Data
-		stored.Message = P.OutputMessage{Data: nil}
+	if !p.retainOutputData {
+		switch e := event.Message.(type) {
+		case P.OutputMessage:
+			outputData = e.Data
+			stored.Message = P.OutputMessage{Data: nil}
+		}
 	}
 
 	p.events = append(p.events, stored)
@@ -78,13 +71,17 @@ func (p *Player) consume(event sessions.Event) {
 
 	switch e := event.Message.(type) {
 	case P.OutputMessage:
-		if len(outputData) == 0 {
+		data := e.Data
+		if !p.retainOutputData {
+			data = outputData
+		}
+		if len(data) == 0 {
 			break
 		}
 
 		// Need to clear dirty state before every write so that the detector works.
 		p.Terminal.Changes().Reset()
-		p.Parse(outputData)
+		p.Parse(data)
 
 		if index >= p.nextDetect {
 			p.detector.Detect(p.Terminal, p.events)


### PR DESCRIPTION
## Summary

- Fixes a deadlock in `Player.consume()` that caused `TestAPI` to flake with a 10-minute timeout in CI
- The `retainOutputData` path released `mu.Lock()` before calling `Goto()`, which re-acquired `mu.Lock()` — this created a window where `cmd/wait` calling `Lines()` could acquire `mu.RLock()` in between, causing a deadlock due to Go's RWMutex writer-priority semantics
- Unified both code paths to hold `mu.Lock()` for the entire `consume()` operation, eliminating the race window

## Details

The deadlock chain was:

1. **Event processing goroutine** (`io.Copy` in `terminal.go:221`): calls `EventStream.Read()` → `Player.Process()` → `Player.consume()` → releases `mu.Lock()` → calls `Goto()` which tries to re-acquire `mu.Lock()` — **blocks**
2. **Test goroutine** (`cmd/wait` in `cmd.go:386`): calls `r.Lines()` → `Player.Lines()` → acquires `mu.RLock()` between the unlock and re-lock above — **blocks** waiting for the pending writer

Once goroutine 2 holds `RLock` and goroutine 1 is waiting for `Lock`, neither can make progress.

The fix inlines the event processing logic (previously delegated to `Goto`) directly into `consume()` under a single lock acquisition — which is what the `!retainOutputData` path already did.

## Test plan

- [x] `go test -race ./pkg/cy/ -run TestAPI` passes consistently (ran 3x, ~12-15s each)
- [x] `go test -race ./pkg/replay/...` all pass
- [x] `go test -race ./pkg/mux/... ./pkg/sessions/... ./pkg/search/...` all pass
- [ ] CI `just test-race` passes

https://claude.ai/code/session_01WYTsz9NrXUesU1GEngukwj