### PR TITLE
fix: docs build failure and add local example validation

### DIFF
--- a/docs/docs/layouts.md
+++ b/docs/docs/layouts.md
@@ -85,7 +85,7 @@ This example uses the following code:
 
 (defn
   border-title
-  [layout]
+  [size layout]
   # Get the NodeID of the node the user is attached to
   (def node (layout/attach-id layout))
   (if

--- a/justfile
+++ b/justfile
@@ -46,6 +46,15 @@ docs-build-assets:
   rm -rf docs/.docusaurus
   cd docs && npm run build
 
+# Validate the Janet code examples embedded in the docs, the same check
+# CI runs. Clears the Docusaurus/webpack caches first so the markdown
+# preprocessor actually re-runs (otherwise cached output is reused and
+# the examples are silently skipped). Skips story asset generation for
+# speed.
+docs-validate:
+  rm -rf docs/.docusaurus docs/node_modules/.cache
+  cd docs && CY_SKIP_ASSETS=1 npm run build
+
 api:
   go run ./cmd/docs/main.go
 

--- a/pkg/cy/api/docs-signal.md
+++ b/pkg/cy/api/docs-signal.md
@@ -23,6 +23,7 @@ Optional named parameters:
 - `:timeout` (number, default 0): Maximum number of seconds to wait. A value of 0 means wait indefinitely. Returns an error if the timeout is reached.
 
 ```janet
+# ignore
 # Wait with a 10-second timeout
 (def result (signal/wait :my-channel :timeout 10))
 (print result)


### PR DESCRIPTION
## Summary

Fixes the docs build CI failure and adds a local command to run CI's Janet example validation.

- **`pkg/cy/api/docs-signal.md`** — the `signal/wait` example blocks forever (nothing sends `:my-channel` in a standalone run), which timed out the example validator and failed the build. Marked `# ignore` like other blocking examples. The non-blocking `signal/send` example stays validated.
- **`docs/docs/layouts.md`** — fixed a dynamic-property arity mismatch. The `:title` property now passes `(size, layout)`, so `border-title` takes `[size layout]`. `border-fg` is preset with only the layout, so it stays `[layout]`. This clears the `function takes at most 1 args, got 2` log lines.
- **`justfile`** — added `just docs-validate`, which runs CI's exact example check locally. It clears both `docs/.docusaurus` and `docs/node_modules/.cache` so the markdown preprocessor actually re-runs; a stale webpack cache otherwise reuses processed output and silently skips validation.

## Test plan

- `just docs-validate` passes: 72 examples validated, 0 property errors.
- Removing `# ignore` reproduces the exact CI failure (`api.md:… timed out waiting for signal "my-channel"`, exit 1); restoring it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)